### PR TITLE
feat: added breakpoints with custom padding for the container class

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,11 +94,17 @@ module.exports = {
     ringWidth: oneLayerWithPixelAdding('ring-width'),
     boxShadow: themeShadowBox(),
     letterSpacing: themeLetterSpacing(),
+    container: {
+      padding: {
+        small: '16px',
+        medium: '24px',
+        large: '112px',
+      },
+    },
     screens: {
-      small: '0',
-      medium: '600px',
-      large: '900px',
-      xlarge: '1301px',
+      small: '375px',
+      medium: '700px',
+      large: '1440px',
     },
   },
   plugins: [require('@tailwindcss/forms')],


### PR DESCRIPTION
## Description 

- Added config for screen sizes as per the design `1440px,700px,375px`
- Customized padding values for the container class `112px` for Desktop, `24px` for Tablet and `16px` for mobile




# Related Issue

- Resolve #22